### PR TITLE
Patch the UCC excitation_list when `include_imaginary is True`.

### DIFF
--- a/qiskit_nature/circuit/library/ansatzes/ucc.py
+++ b/qiskit_nature/circuit/library/ansatzes/ucc.py
@@ -290,7 +290,16 @@ class UCC(EvolvedOperatorAnsatz):
                 # ``None`` for non-commuting operators in order to manually remove them in unison.
                 operators = self.qubit_converter.convert_match(excitation_ops, suppress_none=False)
                 valid_operators, valid_excitations = [], []
-                for op, ex in zip(operators, self._excitation_list):
+
+                if self._include_imaginary:
+                    # Duplicate each excitation to account for the real and imaginary parts.
+                    excitations = []
+                    for ex in self._excitation_list:
+                        excitations.extend([ex, ex])
+                else:
+                    excitations = self._excitation_list
+
+                for op, ex in zip(operators, excitations):
                     if op is not None:
                         valid_operators.append(op)
                         valid_excitations.append(ex)

--- a/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
+++ b/test/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
@@ -563,6 +563,26 @@ class TestGroundStateEigensolver(QiskitNatureTestCase):
         res = calc.solve(self.electronic_structure_problem)
         np.testing.assert_array_almost_equal(res.raw_result.optimal_point, initial_point)
 
+    def test_default_initial_point_with_imaginary_ucc(self):
+        """Test when using the default initial point and the imaginary parts of the UCC ansatz."""
+
+        ansatz = UCCSD(
+            qubit_converter=self.qubit_converter,
+            num_particles=self.num_particles,
+            num_spin_orbitals=self.num_spin_orbitals,
+            include_imaginary=True,
+        )
+        solver = VQEUCCFactory(
+            QuantumInstance(BasicAer.get_backend("statevector_simulator")), ansatz=ansatz
+        )
+        calc = GroundStateEigensolver(self.qubit_converter, solver)
+        res = calc.solve(self.electronic_structure_problem)
+
+        np.testing.assert_array_equal(
+            solver.initial_point.to_numpy_array(), [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        )
+        self.assertAlmostEqual(res.total_energies[0], self.reference_energy, places=6)
+
     def test_vqe_ucc_factory_with_mp2(self):
         """Test when using MP2InitialPoint to generate the initial point."""
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This ensures that the initial point array is computed with the correct shape. See [this](https://github.com/Qiskit/qiskit-nature/pull/455#discussion_r882107994) discussion for the context.

### Details and comments


